### PR TITLE
Docker image optimization: 1.05 GB → 86 MB + vulnerabilities reduced

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,30 @@
-FROM python:3
+###################################################################################
+## Builder
+###################################################################################
+FROM python:3.11-slim AS builder
 
 ARG VERSION
 ENV VERSION=${VERSION:-master}
 
 RUN pip install --upgrade pip
+RUN apt update && apt install -y git
 
-RUN python -m pip install git+https://github.com/eggplants/ghcr-badge@${VERSION}
+# create symlink to emulate distroless python location
+RUN ln -s /usr/local/bin/python3 /usr/bin/python3
+
+# Use the symlink created here
+RUN /usr/bin/python3 -m venv /opt/venv
+
+RUN /opt/venv/bin/pip install git+https://github.com/eggplants/ghcr-badge@${VERSION}
+
+###################################################################################
+## Final image
+###################################################################################
+
+FROM gcr.io/distroless/python3-debian12:nonroot
+
+COPY --from=builder /opt/venv /opt/venv
+
+ENV PATH="/opt/venv/bin:$PATH"
 
 ENTRYPOINT ["ghcr-badge-server"]


### PR DESCRIPTION
I have optimized the Dockerfile to reduce both the image size and the number of vulnerabilities.

The original image (`v0.5.1`) was `1.05 GB` with 434 fixable vulnerabilities.
With this PR, using Google's Distroless image, the resulting image is `86.2 MB` with only 3 fixable vulnerabilities.

Currently, Distroless only supports Python 3.11, but a Debian Trixie image with Python 3.13 is expected soon.
Aside from this, it behaves the same as the original image.