### PR TITLE
Raised number of retrieved tags

### DIFF
--- a/ghcr_badge/generate.py
+++ b/ghcr_badge/generate.py
@@ -344,7 +344,7 @@ class GHCRBadgeGenerator:
                 url,
                 headers={"User-Agent": _USER_AGENT, "Authorization": f"Bearer {token}"},
                 timeout=10,
-                params = params,
+                params=params,
             )
             .json()
             .get("tags")


### PR DESCRIPTION
* fixes #216

The issue raised by #216 came from too many tagged images in that repo. Therefore, the tag filter resolves only based on what it could fetch in one go.

This PR raises the number of fetched tags to 300.

A live example of this fix is available at https://ghcr-badge-ipv2.onrender.com/

A more durable fix (and slower) would be to follow the pagination pattern exposed by the Docker API. Not implemented.