### PR TITLE
Add a pulls count badge endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@
   - defaults: `color=#44cc11`, `tag=latest`, `label=image size`
   - <https://ghcr-badge.egpl.dev/eggplants/ghcr-badge/size>
   - 👉: ![3]
+- `/<package_owner>/<package_name>/downloads?repo=...&color=...&label=...`
+  - defaults: `color=#44cc11`, `label=downloads`
+  - use `repo=...` for repository-scoped package pages
+  - <https://ghcr-badge.egpl.dev/eggplants/ghcr-badge/downloads?repo=ghcr-badge>
 
 ## Common parameters
 
@@ -65,6 +69,13 @@ Use the ignore parameter to filter returned tags, supports pattern matching and 
 ### `color` parameter
 
 Available color names and hex codes are listed on: <https://github.com/jongracecox/anybadge#colors>
+
+### `repo` parameter
+
+Use the `repo` parameter with the `downloads` endpoint when the package is published on a repository-scoped GitHub package page.
+
+- `repo=ghcr-badge` fetches `https://github.com/eggplants/ghcr-badge/pkgs/container/ghcr-badge`
+- omitting `repo` fetches `https://github.com/users/<owner>/packages/container/package/<package>`
 
 ## Note
 

--- a/README.md
+++ b/README.md
@@ -42,9 +42,9 @@
   - defaults: `color=#44cc11`, `tag=latest`, `label=image size`
   - <https://ghcr-badge.egpl.dev/eggplants/ghcr-badge/size>
   - 👉: ![3]
-- `/<package_owner>/<package_name>/downloads?color=...&label=...`
-  - defaults: `color=#44cc11`, `label=downloads`
-  - <https://ghcr-badge.egpl.dev/eggplants/ghcr-badge/downloads>
+- `/<package_owner>/<package_name>/pulls?color=...&label=...`
+  - defaults: `color=#44cc11`, `label=pulls`
+  - <https://ghcr-badge.egpl.dev/eggplants/ghcr-badge/pulls>
 
 ## Common parameters
 

--- a/README.md
+++ b/README.md
@@ -42,10 +42,9 @@
   - defaults: `color=#44cc11`, `tag=latest`, `label=image size`
   - <https://ghcr-badge.egpl.dev/eggplants/ghcr-badge/size>
   - 👉: ![3]
-- `/<package_owner>/<package_name>/downloads?repo=...&color=...&label=...`
+- `/<package_owner>/<package_name>/downloads?color=...&label=...`
   - defaults: `color=#44cc11`, `label=downloads`
-  - use `repo=...` for repository-scoped package pages
-  - <https://ghcr-badge.egpl.dev/eggplants/ghcr-badge/downloads?repo=ghcr-badge>
+  - <https://ghcr-badge.egpl.dev/eggplants/ghcr-badge/downloads>
 
 ## Common parameters
 
@@ -69,13 +68,6 @@ Use the ignore parameter to filter returned tags, supports pattern matching and 
 ### `color` parameter
 
 Available color names and hex codes are listed on: <https://github.com/jongracecox/anybadge#colors>
-
-### `repo` parameter
-
-Use the `repo` parameter with the `downloads` endpoint when the package is published on a repository-scoped GitHub package page.
-
-- `repo=ghcr-badge` fetches `https://github.com/eggplants/ghcr-badge/pkgs/container/ghcr-badge`
-- omitting `repo` fetches `https://github.com/users/<owner>/packages/container/package/<package>`
 
 ## Note
 

--- a/ghcr_badge/generate.py
+++ b/ghcr_badge/generate.py
@@ -231,7 +231,6 @@ class GHCRBadgeGenerator:
         package_owner: str,
         package_name: str,
         *,
-        repo: str | None = None,
         label: str = "downloads",
     ) -> str:
         """Generate image downloads badge.
@@ -244,8 +243,6 @@ class GHCRBadgeGenerator:
             package owner name
         package_name : str
             package name
-        repo : str | None, optional
-            repository name for repository-scoped package pages, by default None
         label : str, optional
             label text, by default "downloads"
 
@@ -256,7 +253,7 @@ class GHCRBadgeGenerator:
 
         """
         try:
-            downloads = self.get_download_count(package_owner, package_name, repo=repo)
+            downloads = self.get_download_count(package_owner, package_name)
         except InvalidDownloadCountError:
             return self.get_invalid_badge(label)
         badge = Badge(
@@ -398,7 +395,7 @@ class GHCRBadgeGenerator:
             raise InvalidTagListError
         return [str(tag) for tag in tags]
 
-    def get_download_count(self: Self, package_owner: str, package_name: str, *, repo: str | None = None) -> str:
+    def get_download_count(self: Self, package_owner: str, package_name: str) -> str:
         """Get download count from a GitHub package page.
 
         Parameters
@@ -409,8 +406,6 @@ class GHCRBadgeGenerator:
             package owner name
         package_name : str
             package name
-        repo : str | None, optional
-            repository name for repository-scoped package pages, by default None
 
         Returns:
         -------
@@ -425,14 +420,9 @@ class GHCRBadgeGenerator:
         """
         if re.match(_GITHUB_USER_PATTERN, package_owner) is None:
             raise InvalidImageError
-        if repo is not None and re.match(_GITHUB_REPO_PATTERN, repo) is None:
-            raise InvalidImageError
 
         encoded_package_name = quote(package_name, safe="")
-        if repo is None:
-            url = f"https://github.com/users/{package_owner}/packages/container/package/{encoded_package_name}"
-        else:
-            url = f"https://github.com/{package_owner}/{repo}/pkgs/container/{encoded_package_name}"
+        url = f"https://github.com/users/{package_owner}/packages/container/package/{encoded_package_name}"
 
         try:
             response = requests.get(url, headers={"User-Agent": _USER_AGENT}, timeout=_TIMEOUT)

--- a/ghcr_badge/generate.py
+++ b/ghcr_badge/generate.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 import base64
 import fnmatch
 import re
+from html import unescape
 from typing import TYPE_CHECKING, cast
+from urllib.parse import quote
 
 import requests
 from anybadge import Badge  # type: ignore[import,unused-ignore]
@@ -39,6 +41,10 @@ class InvalidImageError(Exception):
     """Exception for invalid image."""
 
 
+class InvalidDownloadCountError(Exception):
+    """Exception for invalid download count."""
+
+
 class InvalidMediaTypeError(Exception):
     """Exception for invalid media type."""
 
@@ -55,6 +61,8 @@ _MEDIA_TYPE_MANIFEST_LIST_V2 = f"{_MEDIA_TYPE_MANIFEST}.list.v2+json"
 _MEDIA_TYPE_OCI_IMAGE_MANIFEST = "application/vnd.oci.image.manifest"
 _MEDIA_TYPE_OCI_IMAGE_MANIFEST_V1 = f"{_MEDIA_TYPE_OCI_IMAGE_MANIFEST}.v1+json"
 _MEDIA_TYPE_OCI_IMAGE_INDEX_V1 = "application/vnd.oci.image.index.v1+json"
+
+_TOTAL_DOWNLOADS_PATTERN = re.compile(r"Total downloads[\s\S]{0,500}?<h3\b([^>]*)>([^<]+)</h3>", re.IGNORECASE)
 
 
 class GHCRBadgeGenerator:
@@ -218,6 +226,46 @@ class GHCRBadgeGenerator:
         )
         return str(badge.badge_svg_text)
 
+    def generate_downloads(
+        self: Self,
+        package_owner: str,
+        package_name: str,
+        *,
+        repo: str | None = None,
+        label: str = "downloads",
+    ) -> str:
+        """Generate image downloads badge.
+
+        Parameters
+        ----------
+        self : Self
+            class instance
+        package_owner : str
+            package owner name
+        package_name : str
+            package name
+        repo : str | None, optional
+            repository name for repository-scoped package pages, by default None
+        label : str, optional
+            label text, by default "downloads"
+
+        Returns:
+        -------
+        str
+            svg string of generated badge of download count
+
+        """
+        try:
+            downloads = self.get_download_count(package_owner, package_name, repo=repo)
+        except InvalidDownloadCountError:
+            return self.get_invalid_badge(label)
+        badge = Badge(
+            label=label,
+            value=downloads,
+            default_color=self.color,
+        )
+        return str(badge.badge_svg_text)
+
     def get_manifest(
         self: Self,
         package_owner: str,
@@ -349,6 +397,60 @@ class GHCRBadgeGenerator:
         if not isinstance(tags, list) or len(tags) == 0:
             raise InvalidTagListError
         return [str(tag) for tag in tags]
+
+    def get_download_count(self: Self, package_owner: str, package_name: str, *, repo: str | None = None) -> str:
+        """Get download count from a GitHub package page.
+
+        Parameters
+        ----------
+        self : Self
+            class instance
+        package_owner : str
+            package owner name
+        package_name : str
+            package name
+        repo : str | None, optional
+            repository name for repository-scoped package pages, by default None
+
+        Returns:
+        -------
+        str
+            Displayed download count string, e.g. "1.2K"
+
+        Raises:
+        ------
+        InvalidDownloadCountError
+            raise if the download count cannot be fetched or parsed
+
+        """
+        if re.match(_GITHUB_USER_PATTERN, package_owner) is None:
+            raise InvalidImageError
+        if repo is not None and re.match(_GITHUB_REPO_PATTERN, repo) is None:
+            raise InvalidImageError
+
+        encoded_package_name = quote(package_name, safe="")
+        if repo is None:
+            url = f"https://github.com/users/{package_owner}/packages/container/package/{encoded_package_name}"
+        else:
+            url = f"https://github.com/{package_owner}/{repo}/pkgs/container/{encoded_package_name}"
+
+        try:
+            response = requests.get(url, headers={"User-Agent": _USER_AGENT}, timeout=_TIMEOUT)
+            response.raise_for_status()
+        except requests.RequestException as err:
+            raise InvalidDownloadCountError(str(err)) from err
+
+        matched = _TOTAL_DOWNLOADS_PATTERN.search(response.text)
+        if matched is None:
+            msg = "download count section was not found"
+            raise InvalidDownloadCountError(msg)
+
+        downloads = unescape(matched.group(2)).strip()
+        if not downloads:
+            msg = "download count was empty"
+            raise InvalidDownloadCountError(msg)
+
+        return downloads
 
     def filter_tags(self: Self, package_owner: str, package_name: str) -> list[str]:
         """Filter tags by regex pattern.

--- a/ghcr_badge/generate.py
+++ b/ghcr_badge/generate.py
@@ -41,8 +41,8 @@ class InvalidImageError(Exception):
     """Exception for invalid image."""
 
 
-class InvalidDownloadCountError(Exception):
-    """Exception for invalid download count."""
+class InvalidPullCountError(Exception):
+    """Exception for invalid pull count."""
 
 
 class InvalidMediaTypeError(Exception):
@@ -62,7 +62,7 @@ _MEDIA_TYPE_OCI_IMAGE_MANIFEST = "application/vnd.oci.image.manifest"
 _MEDIA_TYPE_OCI_IMAGE_MANIFEST_V1 = f"{_MEDIA_TYPE_OCI_IMAGE_MANIFEST}.v1+json"
 _MEDIA_TYPE_OCI_IMAGE_INDEX_V1 = "application/vnd.oci.image.index.v1+json"
 
-_TOTAL_DOWNLOADS_PATTERN = re.compile(r"Total downloads[\s\S]{0,500}?<h3\b([^>]*)>([^<]+)</h3>", re.IGNORECASE)
+_TOTAL_PULLS_PATTERN = re.compile(r"Total downloads[\s\S]{0,500}?<h3\b([^>]*)>([^<]+)</h3>", re.IGNORECASE)
 
 
 class GHCRBadgeGenerator:
@@ -226,14 +226,14 @@ class GHCRBadgeGenerator:
         )
         return str(badge.badge_svg_text)
 
-    def generate_downloads(
+    def generate_pulls(
         self: Self,
         package_owner: str,
         package_name: str,
         *,
-        label: str = "downloads",
+        label: str = "pulls",
     ) -> str:
-        """Generate image downloads badge.
+        """Generate image pulls badge.
 
         Parameters
         ----------
@@ -244,21 +244,21 @@ class GHCRBadgeGenerator:
         package_name : str
             package name
         label : str, optional
-            label text, by default "downloads"
+            label text, by default "pulls"
 
         Returns:
         -------
         str
-            svg string of generated badge of download count
+            svg string of generated badge of pull count
 
         """
         try:
-            downloads = self.get_download_count(package_owner, package_name)
-        except InvalidDownloadCountError:
+            pulls = self.get_pull_count(package_owner, package_name)
+        except InvalidPullCountError:
             return self.get_invalid_badge(label)
         badge = Badge(
             label=label,
-            value=downloads,
+            value=pulls,
             default_color=self.color,
         )
         return str(badge.badge_svg_text)
@@ -395,8 +395,8 @@ class GHCRBadgeGenerator:
             raise InvalidTagListError
         return [str(tag) for tag in tags]
 
-    def get_download_count(self: Self, package_owner: str, package_name: str) -> str:
-        """Get download count from a GitHub package page.
+    def get_pull_count(self: Self, package_owner: str, package_name: str) -> str:
+        """Get pull count from a GitHub package page.
 
         Parameters
         ----------
@@ -410,12 +410,12 @@ class GHCRBadgeGenerator:
         Returns:
         -------
         str
-            Displayed download count string, e.g. "1.2K"
+            Displayed pull count string, e.g. "1.2K"
 
         Raises:
         ------
-        InvalidDownloadCountError
-            raise if the download count cannot be fetched or parsed
+        InvalidPullCountError
+            raise if the pull count cannot be fetched or parsed
 
         """
         if re.match(_GITHUB_USER_PATTERN, package_owner) is None:
@@ -428,19 +428,19 @@ class GHCRBadgeGenerator:
             response = requests.get(url, headers={"User-Agent": _USER_AGENT}, timeout=_TIMEOUT)
             response.raise_for_status()
         except requests.RequestException as err:
-            raise InvalidDownloadCountError(str(err)) from err
+            raise InvalidPullCountError(str(err)) from err
 
-        matched = _TOTAL_DOWNLOADS_PATTERN.search(response.text)
+        matched = _TOTAL_PULLS_PATTERN.search(response.text)
         if matched is None:
-            msg = "download count section was not found"
-            raise InvalidDownloadCountError(msg)
+            msg = "pull count section was not found"
+            raise InvalidPullCountError(msg)
 
-        downloads = unescape(matched.group(2)).strip()
-        if not downloads:
-            msg = "download count was empty"
-            raise InvalidDownloadCountError(msg)
+        pulls = unescape(matched.group(2)).strip()
+        if not pulls:
+            msg = "pull count was empty"
+            raise InvalidPullCountError(msg)
 
-        return downloads
+        return pulls
 
     def filter_tags(self: Self, package_owner: str, package_name: str) -> list[str]:
         """Filter tags by regex pattern.

--- a/ghcr_badge/server.py
+++ b/ghcr_badge/server.py
@@ -97,12 +97,14 @@ def __get_index_json() -> Response:
                     "/<package_owner>/<package_name>/tags?color=...&ignore=...&n=...&label=...&trim=...",
                     "/<package_owner>/<package_name>/latest_tag?color=...&ignore=...&label=...&trim=...",
                     "/<package_owner>/<package_name>/size?tag=...&color=...&label=...&trim=...",
+                    "/<package_owner>/<package_name>/downloads?repo=...&color=...&label=...",
                 ],
                 "example_paths": [
                     "/",
                     "/eggplants/ghcr-badge/tags",
                     "/eggplants/ghcr-badge/latest_tag",
                     "/eggplants/ghcr-badge/size",
+                    "/eggplants/ghcr-badge/downloads?repo=ghcr-badge",
                     "/frysztak/orpington-news/size",
                     "/tuananh/aws-cli/size",
                     "/plantuml/docker%2Fjekyll/tags",
@@ -225,6 +227,42 @@ def get_size(package_owner: str, package_name: str) -> Response:
                 package_owner,
                 package_name,
                 tag=tag,
+                label=label,
+            ),
+        )
+    except Exception as err:  # noqa: BLE001
+        return jsonify(exception=type(err).__name__)
+
+    return res
+
+
+@app.route(f"{_PACKAGE_PARAM_RULE}/downloads", methods=["GET"])
+def get_downloads(package_owner: str, package_name: str) -> Response:
+    """Get image downloads as a badge.
+
+    Parameters
+    ----------
+    package_owner : str
+        package owner name, e.g. 'eggplants'
+    package_name : str
+        package name, e.g. 'ghcr-badge'
+
+    Returns:
+    -------
+    Response
+        image download badge
+
+    """
+    try:
+        q_params = request.args
+        repo = q_params.get("repo") or None
+        color = q_params.get("color", "#44cc11")
+        label = q_params.get("label", "downloads")
+        res = return_svg(
+            GHCRBadgeGenerator(color=color).generate_downloads(
+                package_owner,
+                package_name,
+                repo=repo,
                 label=label,
             ),
         )

--- a/ghcr_badge/server.py
+++ b/ghcr_badge/server.py
@@ -97,14 +97,14 @@ def __get_index_json() -> Response:
                     "/<package_owner>/<package_name>/tags?color=...&ignore=...&n=...&label=...&trim=...",
                     "/<package_owner>/<package_name>/latest_tag?color=...&ignore=...&label=...&trim=...",
                     "/<package_owner>/<package_name>/size?tag=...&color=...&label=...&trim=...",
-                    "/<package_owner>/<package_name>/downloads?repo=...&color=...&label=...",
+                    "/<package_owner>/<package_name>/downloads?color=...&label=...",
                 ],
                 "example_paths": [
                     "/",
                     "/eggplants/ghcr-badge/tags",
                     "/eggplants/ghcr-badge/latest_tag",
                     "/eggplants/ghcr-badge/size",
-                    "/eggplants/ghcr-badge/downloads?repo=ghcr-badge",
+                    "/eggplants/ghcr-badge/downloads",
                     "/frysztak/orpington-news/size",
                     "/tuananh/aws-cli/size",
                     "/plantuml/docker%2Fjekyll/tags",
@@ -255,14 +255,12 @@ def get_downloads(package_owner: str, package_name: str) -> Response:
     """
     try:
         q_params = request.args
-        repo = q_params.get("repo") or None
         color = q_params.get("color", "#44cc11")
         label = q_params.get("label", "downloads")
         res = return_svg(
             GHCRBadgeGenerator(color=color).generate_downloads(
                 package_owner,
                 package_name,
-                repo=repo,
                 label=label,
             ),
         )

--- a/ghcr_badge/server.py
+++ b/ghcr_badge/server.py
@@ -97,14 +97,14 @@ def __get_index_json() -> Response:
                     "/<package_owner>/<package_name>/tags?color=...&ignore=...&n=...&label=...&trim=...",
                     "/<package_owner>/<package_name>/latest_tag?color=...&ignore=...&label=...&trim=...",
                     "/<package_owner>/<package_name>/size?tag=...&color=...&label=...&trim=...",
-                    "/<package_owner>/<package_name>/downloads?color=...&label=...",
+                    "/<package_owner>/<package_name>/pulls?color=...&label=...",
                 ],
                 "example_paths": [
                     "/",
                     "/eggplants/ghcr-badge/tags",
                     "/eggplants/ghcr-badge/latest_tag",
                     "/eggplants/ghcr-badge/size",
-                    "/eggplants/ghcr-badge/downloads",
+                    "/eggplants/ghcr-badge/pulls",
                     "/frysztak/orpington-news/size",
                     "/tuananh/aws-cli/size",
                     "/plantuml/docker%2Fjekyll/tags",
@@ -236,9 +236,9 @@ def get_size(package_owner: str, package_name: str) -> Response:
     return res
 
 
-@app.route(f"{_PACKAGE_PARAM_RULE}/downloads", methods=["GET"])
-def get_downloads(package_owner: str, package_name: str) -> Response:
-    """Get image downloads as a badge.
+@app.route(f"{_PACKAGE_PARAM_RULE}/pulls", methods=["GET"])
+def get_pulls(package_owner: str, package_name: str) -> Response:
+    """Get image pulls as a badge.
 
     Parameters
     ----------
@@ -250,15 +250,15 @@ def get_downloads(package_owner: str, package_name: str) -> Response:
     Returns:
     -------
     Response
-        image download badge
+        image pull badge
 
     """
     try:
         q_params = request.args
         color = q_params.get("color", "#44cc11")
-        label = q_params.get("label", "downloads")
+        label = q_params.get("label", "pulls")
         res = return_svg(
-            GHCRBadgeGenerator(color=color).generate_downloads(
+            GHCRBadgeGenerator(color=color).generate_pulls(
                 package_owner,
                 package_name,
                 label=label,

--- a/ghcr_badge/templates/index.j2
+++ b/ghcr_badge/templates/index.j2
@@ -182,25 +182,25 @@
         <button type="submit" onclick="updateImages('size')">Apply</button>
       </div>
       <hr>
-      <h2>downloads</h2>
-      <a id="downloads-link">
-        <img alt="downloads-badge" id="downloads" src="data:,">
+      <h2>pulls</h2>
+      <a id="pulls-link">
+        <img alt="pulls-badge" id="pulls" src="data:,">
       </a>
-      <div class="options" id="downloads-options">
-        <label for="downloads-color">color:</label>
+      <div class="options" id="pulls-options">
+        <label for="pulls-color">color:</label>
         <input type="color"
                name="color"
                class="color"
-               id="downloads-color"
+               id="pulls-color"
                value="#44cc11">
         /
-        <label for="downloads-label">label:</label>
+        <label for="pulls-label">label:</label>
         <input type="text"
                name="label"
                class="label"
-               id="downloads-label"
-               value="downloads">
-        <button type="submit" onclick="updateImages('downloads')">Apply</button>
+               id="pulls-label"
+               value="pulls">
+        <button type="submit" onclick="updateImages('pulls')">Apply</button>
       </div>
       <hr>
     </main>

--- a/ghcr_badge/templates/index.j2
+++ b/ghcr_badge/templates/index.j2
@@ -182,6 +182,30 @@
         <button type="submit" onclick="updateImages('size')">Apply</button>
       </div>
       <hr>
+      <h2>downloads</h2>
+      <a id="downloads-link">
+        <img alt="downloads-badge" id="downloads" src="data:,">
+      </a>
+      <div class="options" id="downloads-options">
+        <label for="downloads-color">color:</label>
+        <input type="color"
+               name="color"
+               class="color"
+               id="downloads-color"
+               value="#44cc11">
+        /
+        <label for="downloads-repo">repo:</label>
+        <input type="text" name="repo" class="repo" id="downloads-repo" value="">
+        /
+        <label for="downloads-label">label:</label>
+        <input type="text"
+               name="label"
+               class="label"
+               id="downloads-label"
+               value="downloads">
+        <button type="submit" onclick="updateImages('downloads')">Apply</button>
+      </div>
+      <hr>
     </main>
     <footer>
       <span>

--- a/ghcr_badge/templates/index.j2
+++ b/ghcr_badge/templates/index.j2
@@ -194,9 +194,6 @@
                id="downloads-color"
                value="#44cc11">
         /
-        <label for="downloads-repo">repo:</label>
-        <input type="text" name="repo" class="repo" id="downloads-repo" value="">
-        /
         <label for="downloads-label">label:</label>
         <input type="text"
                name="label"

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -10,7 +10,7 @@ import requests
 
 from ghcr_badge.generate import (
     GHCRBadgeGenerator,
-    InvalidDownloadCountError,
+    InvalidPullCountError,
     InvalidImageError,
     InvalidManifestError,
     InvalidMediaTypeError,
@@ -129,20 +129,20 @@ class TestGHCRBadgeGenerator:
         result = gen.generate_size("user", "repo")
         assert "invalid" in result
 
-    @patch("ghcr_badge.generate.GHCRBadgeGenerator.get_download_count")
-    def test_generate_downloads_success(self, mock_get_download_count: MagicMock) -> None:
-        """Test generate_downloads with successful response."""
-        mock_get_download_count.return_value = "1.2K"
+    @patch("ghcr_badge.generate.GHCRBadgeGenerator.get_pull_count")
+    def test_generate_pulls_success(self, mock_get_pull_count: MagicMock) -> None:
+        """Test generate_pulls with successful response."""
+        mock_get_pull_count.return_value = "1.2K"
         gen = GHCRBadgeGenerator()
-        result = gen.generate_downloads("user", "repo")
+        result = gen.generate_pulls("user", "repo")
         assert "1.2K" in result
 
-    @patch("ghcr_badge.generate.GHCRBadgeGenerator.get_download_count")
-    def test_generate_downloads_invalid(self, mock_get_download_count: MagicMock) -> None:
-        """Test generate_downloads with invalid response."""
-        mock_get_download_count.side_effect = InvalidDownloadCountError
+    @patch("ghcr_badge.generate.GHCRBadgeGenerator.get_pull_count")
+    def test_generate_pulls_invalid(self, mock_get_pull_count: MagicMock) -> None:
+        """Test generate_pulls with invalid response."""
+        mock_get_pull_count.side_effect = InvalidPullCountError
         gen = GHCRBadgeGenerator()
-        result = gen.generate_downloads("user", "repo")
+        result = gen.generate_pulls("user", "repo")
         assert "invalid" in result
 
     @patch("ghcr_badge.generate.requests.get")
@@ -259,15 +259,15 @@ class TestGHCRBadgeGenerator:
             gen.get_tags("user", "repo")
 
     @patch("ghcr_badge.generate.requests.get")
-    def test_get_download_count_user_scoped(self, mock_get: MagicMock) -> None:
-        """Test get_download_count for a user-scoped package page."""
+    def test_get_pull_count_user_scoped(self, mock_get: MagicMock) -> None:
+        """Test get_pull_count for a user-scoped package page."""
         mock_response = Mock()
         mock_response.raise_for_status.return_value = None
         mock_response.text = '<section><span>Total downloads</span><h3 title="1,234">1.2K</h3></section>'
         mock_get.return_value = mock_response
 
         gen = GHCRBadgeGenerator()
-        result = gen.get_download_count("user", "repo")
+        result = gen.get_pull_count("user", "repo")
 
         assert result == "1.2K"
         mock_get.assert_called_once_with(
@@ -277,27 +277,27 @@ class TestGHCRBadgeGenerator:
         )
 
     @patch("ghcr_badge.generate.requests.get")
-    def test_get_download_count_invalid_response(self, mock_get: MagicMock) -> None:
-        """Test get_download_count when the page does not contain a count."""
+    def test_get_pull_count_invalid_response(self, mock_get: MagicMock) -> None:
+        """Test get_pull_count when the page does not contain a count."""
         mock_response = Mock()
         mock_response.raise_for_status.return_value = None
         mock_response.text = "<html><body>No stats here</body></html>"
         mock_get.return_value = mock_response
 
         gen = GHCRBadgeGenerator()
-        with pytest.raises(InvalidDownloadCountError, match="section was not found"):
-            gen.get_download_count("user", "repo")
+        with pytest.raises(InvalidPullCountError, match="section was not found"):
+            gen.get_pull_count("user", "repo")
 
     @patch("ghcr_badge.generate.requests.get")
-    def test_get_download_count_http_error(self, mock_get: MagicMock) -> None:
-        """Test get_download_count when the package page request fails."""
+    def test_get_pull_count_http_error(self, mock_get: MagicMock) -> None:
+        """Test get_pull_count when the package page request fails."""
         mock_response = Mock()
         mock_response.raise_for_status.side_effect = requests.HTTPError("404 Client Error")
         mock_get.return_value = mock_response
 
         gen = GHCRBadgeGenerator()
-        with pytest.raises(InvalidDownloadCountError, match="404 Client Error"):
-            gen.get_download_count("user", "repo")
+        with pytest.raises(InvalidPullCountError, match="404 Client Error"):
+            gen.get_pull_count("user", "repo")
 
     @patch("ghcr_badge.generate.GHCRBadgeGenerator.get_tags")
     def test_filter_tags_basic(self, mock_get_tags: MagicMock) -> None:

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -6,9 +6,11 @@ from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
+import requests
 
 from ghcr_badge.generate import (
     GHCRBadgeGenerator,
+    InvalidDownloadCountError,
     InvalidImageError,
     InvalidManifestError,
     InvalidMediaTypeError,
@@ -127,6 +129,22 @@ class TestGHCRBadgeGenerator:
         result = gen.generate_size("user", "repo")
         assert "invalid" in result
 
+    @patch("ghcr_badge.generate.GHCRBadgeGenerator.get_download_count")
+    def test_generate_downloads_success(self, mock_get_download_count: MagicMock) -> None:
+        """Test generate_downloads with successful response."""
+        mock_get_download_count.return_value = "1.2K"
+        gen = GHCRBadgeGenerator()
+        result = gen.generate_downloads("user", "repo")
+        assert "1.2K" in result
+
+    @patch("ghcr_badge.generate.GHCRBadgeGenerator.get_download_count")
+    def test_generate_downloads_invalid(self, mock_get_download_count: MagicMock) -> None:
+        """Test generate_downloads with invalid response."""
+        mock_get_download_count.side_effect = InvalidDownloadCountError
+        gen = GHCRBadgeGenerator()
+        result = gen.generate_downloads("user", "repo")
+        assert "invalid" in result
+
     @patch("ghcr_badge.generate.requests.get")
     def test_get_manifest_manifest_v2(self, mock_get: MagicMock) -> None:
         """Test get_manifest with ManifestV2 response."""
@@ -239,6 +257,65 @@ class TestGHCRBadgeGenerator:
         gen = GHCRBadgeGenerator()
         with pytest.raises(InvalidTagListError):
             gen.get_tags("user", "repo")
+
+    @patch("ghcr_badge.generate.requests.get")
+    def test_get_download_count_user_scoped(self, mock_get: MagicMock) -> None:
+        """Test get_download_count for a user-scoped package page."""
+        mock_response = Mock()
+        mock_response.raise_for_status.return_value = None
+        mock_response.text = '<section><span>Total downloads</span><h3 title="1,234">1.2K</h3></section>'
+        mock_get.return_value = mock_response
+
+        gen = GHCRBadgeGenerator()
+        result = gen.get_download_count("user", "repo")
+
+        assert result == "1.2K"
+        mock_get.assert_called_once_with(
+            "https://github.com/users/user/packages/container/package/repo",
+            headers={"User-Agent": "Docker-Client/20.10.2 (linux)"},
+            timeout=10,
+        )
+
+    @patch("ghcr_badge.generate.requests.get")
+    def test_get_download_count_repo_scoped(self, mock_get: MagicMock) -> None:
+        """Test get_download_count for a repository-scoped package page."""
+        mock_response = Mock()
+        mock_response.raise_for_status.return_value = None
+        mock_response.text = '<section>Total downloads<div><h3 title="56,789">56.8K</h3></div></section>'
+        mock_get.return_value = mock_response
+
+        gen = GHCRBadgeGenerator()
+        result = gen.get_download_count("user", "docker/jekyll", repo="docs")
+
+        assert result == "56.8K"
+        mock_get.assert_called_once_with(
+            "https://github.com/user/docs/pkgs/container/docker%2Fjekyll",
+            headers={"User-Agent": "Docker-Client/20.10.2 (linux)"},
+            timeout=10,
+        )
+
+    @patch("ghcr_badge.generate.requests.get")
+    def test_get_download_count_invalid_response(self, mock_get: MagicMock) -> None:
+        """Test get_download_count when the page does not contain a count."""
+        mock_response = Mock()
+        mock_response.raise_for_status.return_value = None
+        mock_response.text = "<html><body>No stats here</body></html>"
+        mock_get.return_value = mock_response
+
+        gen = GHCRBadgeGenerator()
+        with pytest.raises(InvalidDownloadCountError, match="section was not found"):
+            gen.get_download_count("user", "repo")
+
+    @patch("ghcr_badge.generate.requests.get")
+    def test_get_download_count_http_error(self, mock_get: MagicMock) -> None:
+        """Test get_download_count when the package page request fails."""
+        mock_response = Mock()
+        mock_response.raise_for_status.side_effect = requests.HTTPError("404 Client Error")
+        mock_get.return_value = mock_response
+
+        gen = GHCRBadgeGenerator()
+        with pytest.raises(InvalidDownloadCountError, match="404 Client Error"):
+            gen.get_download_count("user", "repo")
 
     @patch("ghcr_badge.generate.GHCRBadgeGenerator.get_tags")
     def test_filter_tags_basic(self, mock_get_tags: MagicMock) -> None:

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -277,24 +277,6 @@ class TestGHCRBadgeGenerator:
         )
 
     @patch("ghcr_badge.generate.requests.get")
-    def test_get_download_count_repo_scoped(self, mock_get: MagicMock) -> None:
-        """Test get_download_count for a repository-scoped package page."""
-        mock_response = Mock()
-        mock_response.raise_for_status.return_value = None
-        mock_response.text = '<section>Total downloads<div><h3 title="56,789">56.8K</h3></div></section>'
-        mock_get.return_value = mock_response
-
-        gen = GHCRBadgeGenerator()
-        result = gen.get_download_count("user", "docker/jekyll", repo="docs")
-
-        assert result == "56.8K"
-        mock_get.assert_called_once_with(
-            "https://github.com/user/docs/pkgs/container/docker%2Fjekyll",
-            headers={"User-Agent": "Docker-Client/20.10.2 (linux)"},
-            timeout=10,
-        )
-
-    @patch("ghcr_badge.generate.requests.get")
     def test_get_download_count_invalid_response(self, mock_get: MagicMock) -> None:
         """Test get_download_count when the page does not contain a count."""
         mock_response = Mock()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -193,7 +193,6 @@ class TestDownloadsRoute:
         mock_generator.generate_downloads.assert_called_once_with(
             "testuser",
             "testrepo",
-            repo=None,
             label="downloads",
         )
 
@@ -204,13 +203,12 @@ class TestDownloadsRoute:
         mock_generator.generate_downloads.return_value = "<svg><text>3.4K</text></svg>"
         mock_generator_class.return_value = mock_generator
 
-        response = client.get("/testuser/testrepo/downloads?repo=myrepo&color=blue&label=pulls")
+        response = client.get("/testuser/testrepo/downloads?color=blue&label=pulls")
         assert response.status_code == 200
         mock_generator_class.assert_called_once_with(color="blue")
         mock_generator.generate_downloads.assert_called_once_with(
             "testuser",
             "testrepo",
-            repo="myrepo",
             label="pulls",
         )
 
@@ -221,12 +219,11 @@ class TestDownloadsRoute:
         mock_generator.generate_downloads.return_value = "<svg><text>9</text></svg>"
         mock_generator_class.return_value = mock_generator
 
-        response = client.get("/testuser/nested/path/repo/downloads?repo=demo")
+        response = client.get("/testuser/nested/path/repo/downloads")
         assert response.status_code == 200
         mock_generator.generate_downloads.assert_called_once_with(
             "testuser",
             "nested/path/repo",
-            repo="demo",
             label="downloads",
         )
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -67,7 +67,7 @@ class TestIndexRoute:
         assert response.content_type == "application/json"
         data = response.get_json()
         assert "available_paths" in data
-        assert any("/downloads" in path for path in data["available_paths"])
+        assert any("/pulls" in path for path in data["available_paths"])
 
 
 class TestTagsRoute:
@@ -176,55 +176,55 @@ class TestSizeRoute:
         mock_generator.generate_size.assert_called_once_with("testuser", "org/repo", tag="latest", label="image size")
 
 
-class TestDownloadsRoute:
-    """Test downloads route."""
+class TestPullsRoute:
+    """Test pulls route."""
 
     @patch("ghcr_badge.server.GHCRBadgeGenerator")
-    def test_get_downloads_default(self, mock_generator_class: MagicMock, client: FlaskClient) -> None:
-        """Test GET /<owner>/<name>/downloads with default parameters."""
+    def test_get_pulls_default(self, mock_generator_class: MagicMock, client: FlaskClient) -> None:
+        """Test GET /<owner>/<name>/pulls with default parameters."""
         mock_generator = Mock()
-        mock_generator.generate_downloads.return_value = "<svg><text>1.2K</text></svg>"
+        mock_generator.generate_pulls.return_value = "<svg><text>1.2K</text></svg>"
         mock_generator_class.return_value = mock_generator
 
-        response = client.get("/testuser/testrepo/downloads")
+        response = client.get("/testuser/testrepo/pulls")
         assert response.status_code == 200
         assert response.mimetype == "image/svg+xml"
         mock_generator_class.assert_called_once_with(color="#44cc11")
-        mock_generator.generate_downloads.assert_called_once_with(
-            "testuser",
-            "testrepo",
-            label="downloads",
-        )
-
-    @patch("ghcr_badge.server.GHCRBadgeGenerator")
-    def test_get_downloads_with_parameters(self, mock_generator_class: MagicMock, client: FlaskClient) -> None:
-        """Test GET /<owner>/<name>/downloads with custom parameters."""
-        mock_generator = Mock()
-        mock_generator.generate_downloads.return_value = "<svg><text>3.4K</text></svg>"
-        mock_generator_class.return_value = mock_generator
-
-        response = client.get("/testuser/testrepo/downloads?color=blue&label=pulls")
-        assert response.status_code == 200
-        mock_generator_class.assert_called_once_with(color="blue")
-        mock_generator.generate_downloads.assert_called_once_with(
+        mock_generator.generate_pulls.assert_called_once_with(
             "testuser",
             "testrepo",
             label="pulls",
         )
 
     @patch("ghcr_badge.server.GHCRBadgeGenerator")
-    def test_get_downloads_nested_path(self, mock_generator_class: MagicMock, client: FlaskClient) -> None:
-        """Test GET downloads with nested package path."""
+    def test_get_pulls_with_parameters(self, mock_generator_class: MagicMock, client: FlaskClient) -> None:
+        """Test GET /<owner>/<name>/pulls with custom parameters."""
         mock_generator = Mock()
-        mock_generator.generate_downloads.return_value = "<svg><text>9</text></svg>"
+        mock_generator.generate_pulls.return_value = "<svg><text>3.4K</text></svg>"
         mock_generator_class.return_value = mock_generator
 
-        response = client.get("/testuser/nested/path/repo/downloads")
+        response = client.get("/testuser/testrepo/pulls?color=blue&label=container%20pulls")
         assert response.status_code == 200
-        mock_generator.generate_downloads.assert_called_once_with(
+        mock_generator_class.assert_called_once_with(color="blue")
+        mock_generator.generate_pulls.assert_called_once_with(
+            "testuser",
+            "testrepo",
+            label="container pulls",
+        )
+
+    @patch("ghcr_badge.server.GHCRBadgeGenerator")
+    def test_get_pulls_nested_path(self, mock_generator_class: MagicMock, client: FlaskClient) -> None:
+        """Test GET pulls with nested package path."""
+        mock_generator = Mock()
+        mock_generator.generate_pulls.return_value = "<svg><text>9</text></svg>"
+        mock_generator_class.return_value = mock_generator
+
+        response = client.get("/testuser/nested/path/repo/pulls")
+        assert response.status_code == 200
+        mock_generator.generate_pulls.assert_called_once_with(
             "testuser",
             "nested/path/repo",
-            label="downloads",
+            label="pulls",
         )
 
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -67,6 +67,7 @@ class TestIndexRoute:
         assert response.content_type == "application/json"
         data = response.get_json()
         assert "available_paths" in data
+        assert any("/downloads" in path for path in data["available_paths"])
 
 
 class TestTagsRoute:
@@ -173,6 +174,61 @@ class TestSizeRoute:
         response = client.get("/testuser/org/repo/size")
         assert response.status_code == 200
         mock_generator.generate_size.assert_called_once_with("testuser", "org/repo", tag="latest", label="image size")
+
+
+class TestDownloadsRoute:
+    """Test downloads route."""
+
+    @patch("ghcr_badge.server.GHCRBadgeGenerator")
+    def test_get_downloads_default(self, mock_generator_class: MagicMock, client: FlaskClient) -> None:
+        """Test GET /<owner>/<name>/downloads with default parameters."""
+        mock_generator = Mock()
+        mock_generator.generate_downloads.return_value = "<svg><text>1.2K</text></svg>"
+        mock_generator_class.return_value = mock_generator
+
+        response = client.get("/testuser/testrepo/downloads")
+        assert response.status_code == 200
+        assert response.mimetype == "image/svg+xml"
+        mock_generator_class.assert_called_once_with(color="#44cc11")
+        mock_generator.generate_downloads.assert_called_once_with(
+            "testuser",
+            "testrepo",
+            repo=None,
+            label="downloads",
+        )
+
+    @patch("ghcr_badge.server.GHCRBadgeGenerator")
+    def test_get_downloads_with_parameters(self, mock_generator_class: MagicMock, client: FlaskClient) -> None:
+        """Test GET /<owner>/<name>/downloads with custom parameters."""
+        mock_generator = Mock()
+        mock_generator.generate_downloads.return_value = "<svg><text>3.4K</text></svg>"
+        mock_generator_class.return_value = mock_generator
+
+        response = client.get("/testuser/testrepo/downloads?repo=myrepo&color=blue&label=pulls")
+        assert response.status_code == 200
+        mock_generator_class.assert_called_once_with(color="blue")
+        mock_generator.generate_downloads.assert_called_once_with(
+            "testuser",
+            "testrepo",
+            repo="myrepo",
+            label="pulls",
+        )
+
+    @patch("ghcr_badge.server.GHCRBadgeGenerator")
+    def test_get_downloads_nested_path(self, mock_generator_class: MagicMock, client: FlaskClient) -> None:
+        """Test GET downloads with nested package path."""
+        mock_generator = Mock()
+        mock_generator.generate_downloads.return_value = "<svg><text>9</text></svg>"
+        mock_generator_class.return_value = mock_generator
+
+        response = client.get("/testuser/nested/path/repo/downloads?repo=demo")
+        assert response.status_code == 200
+        mock_generator.generate_downloads.assert_called_once_with(
+            "testuser",
+            "nested/path/repo",
+            repo="demo",
+            label="downloads",
+        )
 
 
 class TestMain:


### PR DESCRIPTION
I was maintaining a similar repo to this one of the same name at [eliasbenb/ghcr-badge](eliasbenb/ghcr-badge). However, it was focused on ghcr download counts, not tags/image size. It would be nice to consolidate download counts badges into this repo.

Note i: the GH API does not currently expose Docker image download counts. The method eliasbenb/ghcr-badge, and this PR, uses is HTML parsing of the` https://github.com/users/{package_owner}/packages/container/package/{package_name}` page, which will output a download count in an HTML title attribute. So, needless to say, it's a little janky (but it works).

Note ii: I'm not sure if I'm just missing something, but this repo doesn't seem to support repository-scoped packages, e.g `ghcr.io/henrygd/beszel/beszel` - this is a package that's hosted under a repo of a personal GitHub account, so it has 3 path parameters. If it's missing, I would suggest it as a feature.

## What changed

- add `GHCRBadgeGenerator.generate_downloads()` and GitHub package page parsing in `ghcr_badge/generate.py`
- add `/<package_owner>/<package_name>/downloads` in `ghcr_badge/server.py`
